### PR TITLE
test: get region from secmgr prefs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ moved {
 
 # Variable to extract API key value
 locals {
-  apikey        = lookup(one(ibm_iam_service_api_key.iam_serviceid_apikey[*]), "apikey")
+  apikey        = one(ibm_iam_service_api_key.iam_serviceid_apikey[*])["apikey"]
   apikey_output = var.display_iam_secret_generator_apikey == true ? nonsensitive(local.apikey) : "not-displayed"
 }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -16,10 +16,11 @@ func TestRunDefaultExample(t *testing.T) {
 	t.Parallel()
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  defaultExampleTerraformDir,
-		Prefix:        "sm-iam-eng",
-		ResourceGroup: resourceGroup,
+		Testing:            t,
+		TerraformDir:       defaultExampleTerraformDir,
+		Prefix:             "sm-iam-eng",
+		ResourceGroup:      resourceGroup,
+		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-secmgr-prefs.yaml",
 	})
 
 	output, err := options.RunTestConsistency()
@@ -31,10 +32,11 @@ func TestRunUpgradeExample(t *testing.T) {
 	t.Parallel()
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  defaultExampleTerraformDir,
-		Prefix:        "sm-iam-eng-upg",
-		ResourceGroup: resourceGroup,
+		Testing:            t,
+		TerraformDir:       defaultExampleTerraformDir,
+		Prefix:             "sm-iam-eng-upg",
+		ResourceGroup:      resourceGroup,
+		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-secmgr-prefs.yaml",
 	})
 
 	output, err := options.RunTestUpgrade()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -12,16 +12,21 @@ import (
 const resourceGroup = "geretain-test-sm-iam-eng"
 const defaultExampleTerraformDir = "examples/basic"
 
-func TestRunDefaultExample(t *testing.T) {
-	t.Parallel()
-
+func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:            t,
-		TerraformDir:       defaultExampleTerraformDir,
-		Prefix:             "sm-iam-eng",
+		TerraformDir:       dir,
+		Prefix:             prefix,
 		ResourceGroup:      resourceGroup,
 		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-secmgr-prefs.yaml",
 	})
+	return options
+}
+
+func TestRunDefaultExample(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptions(t, "sm-iam-eng", defaultExampleTerraformDir)
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
@@ -31,13 +36,7 @@ func TestRunDefaultExample(t *testing.T) {
 func TestRunUpgradeExample(t *testing.T) {
 	t.Parallel()
 
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:            t,
-		TerraformDir:       defaultExampleTerraformDir,
-		Prefix:             "sm-iam-eng-upg",
-		ResourceGroup:      resourceGroup,
-		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-secmgr-prefs.yaml",
-	})
+	options := setupOptions(t, "sm-iam-eng-upg", defaultExampleTerraformDir)
 
 	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {


### PR DESCRIPTION
### Description

Eu-es does not have the quota increase for SM instances. This is set in secmgr prefs file in common-dev-assets. Update test to pick up this file.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
