### PR TITLE
feat: always grant service ID 'Service ID creator' access

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-03-28T18:45:52Z",
+  "generated_at": "2024-04-28T18:45:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The module supports the following operations:
 
 - Creates a new Service ID.
 - Assigns the new Service ID "Editor" role access for `iam-groups`.
-- Assigns the new Service ID "Operator" role access for `iam-identity`. If user set the input variable add_service_id_creator_role to true, this module will also add "Service ID creator" role access for `iam-identity`. It is recommended to set it true if the service ID creation is disabled in the IAM settings.
+- Assigns the new Service ID "Operator" and "Service ID creator" role access for `iam-identity`.
 - Creates a new API key for the Service ID.
 - Optionally creates a secrets group, if an existing one is not passed in.
 - Creates a new arbitrary secret in the Secret Group with the generated Service ID API key value. Because it is an arbitrary secret, the IAM engine does not create the key or manage its rotation.
@@ -94,7 +94,6 @@ You need the following permissions to run this module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_add_service_id_creator_role"></a> [add\_service\_id\_creator\_role](#input\_add\_service\_id\_creator\_role) | Optionally, add service id creator role to the generated service id. This is only required if the creation of service IDs in your IAM settings is disabled. | `bool` | `false` | no |
 | <a name="input_display_iam_secret_generator_apikey"></a> [display\_iam\_secret\_generator\_apikey](#input\_display\_iam\_secret\_generator\_apikey) | Set to true to display the iam\_secret\_generator\_apikey serviceID API Key in output. Should only be used by account admins. | `bool` | `false` | no |
 | <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |
 | <a name="input_existing_secret_group_id"></a> [existing\_secret\_group\_id](#input\_existing\_secret\_group\_id) | The ID of an existing secret group that the Service ID (used to configure IAM secret engine) apikey secret will be added to. If null, a new group is created using the value in var.new\_secret\_group\_name. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "ibm_iam_service_policy" "iam_secret_generator_policy1" {
 
 # create policy for iam identity service.
 locals {
-  iam_identity_roles = var.add_service_id_creator_role ? ["Operator", "Service ID creator"] : ["Operator"]
+  iam_identity_roles = ["Operator", "Service ID creator"]
 }
 
 resource "ibm_iam_service_policy" "iam_secret_generator_policy2" {

--- a/variables.tf
+++ b/variables.tf
@@ -83,10 +83,4 @@ variable "iam_engine_name" {
   description = "The name of the IAM Engine to create."
 }
 
-variable "add_service_id_creator_role" {
-  type        = bool
-  description = "Optionally, add service id creator role to the generated service id. This is only required if the creation of service IDs in your IAM settings is disabled."
-  default     = false
-}
-
 ##############################################################################


### PR DESCRIPTION
### Description

- removed the variable `add_service_id_creator_role` and by default now always grant service ID 'Service ID creator' access

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
